### PR TITLE
docker tips: recommended gem caching

### DIFF
--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -1,18 +1,12 @@
 FROM ruby:2.4.0
 
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN apt-get update -qq && apt-get install -y build-essential libpq-dev
+RUN URL='https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64.deb'; FILE=$(mktemp); curl -L "$URL" -o $FILE && dpkg -i $FILE; rm $FILE
+RUN URL='https://nodejs.org/dist/v6.10.3/node-v6.10.3.tar.xz'; FILE=$(mktemp); curl -L "$URL" -o $FILE && tar -C /usr/local --strip-components 1 -xJf $FILE; rm $FILE
 
+ENV LANG C.UTF-8
 ENV APP_HOME /#{app_name}
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
-
-ADD Gemfile* $APP_HOME/
-
-# Cache the gems
-ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
-  BUNDLE_JOBS=2 \
-  BUNDLE_PATH=/bundle
-
-RUN bundle install
 
 ADD . $APP_HOME

--- a/rails_docker/docker-compose.yml
+++ b/rails_docker/docker-compose.yml
@@ -9,10 +9,15 @@ services:
       - "5432:5432"
 
   web:
+    command: dumb-init bash -c "bundle check || bundle install && rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     depends_on:
       - db
     build: .
     ports:
-      - '3000:3000'
+      - "3000:3000"
     volumes:
       - '.:/#{app_name}'
+      - "ruby-bundle:/usr/local/bundle"
+
+volumes:
+  ruby-bundle:


### PR DESCRIPTION
I'm not sure how you guys use this template.  
But I guess you will spend a lot of time when you made a change to Gemfile.  
I'm not sure if your `cache the gem` section work properly. (Seems to me it is not)  
  
This is my recommendation about gem caching.  
Basically I think it should be cached at compose level and no `bundle install` at the docker image itself.  
Not really sure if it compatible with your current configuration though.  
  
plus some related goodies e.g. dumb-init, and up-to-date nodejs  
I personally don't use the template though.  
So no test performed.