### PR TITLE
Disable instance variable assumption detector for controllers

### DIFF
--- a/shared/linters/config.reek
+++ b/shared/linters/config.reek
@@ -10,6 +10,20 @@ DataClump:
 
 ### Directory specific configuration
 "app/controllers":
+  IrresponsibleModule:
+    enabled: false
+  NestedIterators:
+    max_allowed_nesting: 2
+  UnusedPrivateMethod:
+    enabled: false
+  InstanceVariableAssumption:
+    enabled: false
+"app/helpers":
+  IrresponsibleModule:
+    enabled: false
+  UtilityFunction:
+    enabled: false
+"app/mailers":
   InstanceVariableAssumption:
     enabled: false
 "db/migrate/":

--- a/shared/linters/config.reek
+++ b/shared/linters/config.reek
@@ -9,6 +9,9 @@ DataClump:
   min_clump_size: 3
 
 ### Directory specific configuration
+"app/controllers":
+  InstanceVariableAssumption:
+    enabled: false
 "db/migrate/":
   FeatureEnvy:
     enabled: false


### PR DESCRIPTION
In Braive, we have many usage of the pattern where we set the instance through `before_action` like this https://github.com/troessner/reek/issues/1133, which the error should not be raised. 

And also in controllers, there might be many used of the instance variables. It might be good if we disable it.