### PR TITLE
Add missing rspec config for Sidekiq

### DIFF
--- a/shared/rspec/support/sidekiq.rb
+++ b/shared/rspec/support/sidekiq.rb
@@ -1,0 +1,9 @@
+require 'sidekiq/testing'
+
+Sidekiq::Testing.fake!
+
+RSpec.configure do |config|
+  config.before(:each) do
+    Sidekiq::Worker.clear_all
+  end
+end


### PR DESCRIPTION
Sidekiq was added into the base template #38 but it's missing the default rspec config we usually use