### PR TITLE
Update transactional fixtures for using in system test

### DIFF
--- a/shared/rspec/rails_helper.rb
+++ b/shared/rspec/rails_helper.rb
@@ -13,6 +13,7 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
   config.fixture_path = Rails.root.join('spec', 'fabricators')
 
+  # Set `true` for using in System test
   config.use_transactional_fixtures = true
 
   config.infer_spec_type_from_file_location!

--- a/shared/rspec/rails_helper.rb
+++ b/shared/rspec/rails_helper.rb
@@ -13,7 +13,7 @@ ActiveRecord::Migration.maintain_test_schema!
 RSpec.configure do |config|
   config.fixture_path = Rails.root.join('spec', 'fabricators')
 
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 
   config.infer_spec_type_from_file_location!
 


### PR DESCRIPTION
We should set it to `true` because of use in System test.