### PR TITLE
Add Chrome Headless for system specs

### DIFF
--- a/rails_docker/Dockerfile
+++ b/rails_docker/Dockerfile
@@ -10,6 +10,9 @@ ENV BUNDLE_GEMFILE=$APP_HOME/Gemfile \
 
 ENV NODE_VERSION="8"
 
+ENV CHROMEDRIVER_VERSION="2.35" \
+    CHROMEDRIVER_DIR=/chromedriver
+
 ENV LANG="en_US.UTF-8" \
     LC_ALL="en_US.UTF-8" \
     LANGUAGE="en_US:en"
@@ -26,11 +29,24 @@ RUN apt-key add /tmp/yarn-pubkey.gpg && rm /tmp/yarn-pubkey.gpg && \
 # This will have more up-to-date versions of Node.js than the official Debian repositories
 RUN curl -sL https://deb.nodesource.com/setup_"$NODE_VERSION".x | bash -
 
-# Install Node JS related packages & general required core packages
-RUN apt-get install -y --no-install-recommends build-essential libpq-dev nodejs yarn && \
-    apt-get install -y --no-install-recommends rsync locales chrpath pkg-config libfreetype6 libfontconfig1 && \
+# Set up the Chrome PPA to install Chrome Headless
+ADD https://dl-ssl.google.com/linux/linux_signing_key.pub /tmp/google-pubkey.gpg
+RUN apt-key add /tmp/google-pubkey.gpg && rm /tmp/google-pubkey.gpg  && \
+    echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google.list
+
+# Install general required core packages, Node JS related packages and Chrome (testing)
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends build-essential libpq-dev nodejs yarn google-chrome-stable && \
+    apt-get install -y --no-install-recommends rsync locales chrpath pkg-config libfreetype6 libfontconfig1 git cmake wget unzip && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Download and install Chromedriver
+RUN mkdir "$CHROMEDRIVER_DIR" && \
+    wget -q --continue -P $CHROMEDRIVER_DIR "http://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip" && \
+    unzip $CHROMEDRIVER_DIR/chromedriver* -d $CHROMEDRIVER_DIR
+
+ENV PATH $CHROMEDRIVER_DIR:$PATH
 
 RUN sed -i "s/^#\ \+\(en_US.UTF-8\)/\1/" /etc/locale.gen
 RUN locale-gen en_US.UTF-8

--- a/shared/rspec/support/capybara.rb
+++ b/shared/rspec/support/capybara.rb
@@ -1,7 +1,18 @@
+require 'selenium-webdriver'
+require 'capybara'
+
 # https://github.com/rails/rails/pull/30876
 Capybara.register_driver(:headless_chrome) do |app|
+  # no-sandbox
+  #   Because the user namespace is not enabled in the container by default
+  # headless
+  #   Runs without actually launching gui
+  # disable-gpu
+  #   Disables graphics processing unit(GPU) hardware acceleration
+  # window-size
+  #   sets default window size in case the smaller default size is not enough
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless disable-gpu window-size=1280,720] }
+    chromeOptions: { args: %w[no-sandbox headless disable-gpu window-size=1280,720] }
   )
 
   Capybara::Selenium::Driver.new(


### PR DESCRIPTION
Since tests are run inside a Docker container via `docker-compose.test.yml`, Google Chrome needs to be added to be able to run system specs.

- [x] Update the Dockerfile with the setup of Google Chrome 
- [x] Update the Capybara config for the `headless_chrome` driver
