### PR TITLE
[CHORE] Migrate the PR template to subdirectory .github

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-https://merchantlabs.atlassian.net/browse/AMZ-??
- 
 ## What happened
 Describe the big picture of your changes here to communicate to team why we should accept this pull request. 
  


### PR DESCRIPTION
## What happened
The PR template contained links for another project so needed to be modified. 
 