### PR TITLE
Fix: Incomplete port mapping for all Docker Compose services

### DIFF
--- a/rails_docker/docker-compose.dev.yml
+++ b/rails_docker/docker-compose.dev.yml
@@ -7,4 +7,4 @@ services:
     environment:
       - POSTGRES_DB=#{app_name}_development
     ports:
-      - "5432"
+      - "5432:5432"

--- a/rails_docker/docker-compose.test.yml
+++ b/rails_docker/docker-compose.test.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - POSTGRES_DB=#{app_name}_test
     ports:
-      - "5432"
+      - "5432:5432"
 
   test:
     build:

--- a/rails_docker/docker-compose.yml
+++ b/rails_docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - POSTGRES_DB=#{app_name}_production
     ports:
-      - "5432"
+      - "5432:5432"
 
   web:
     build:


### PR DESCRIPTION
## What happened
In order for port mapping to work, it needs both the local port and the external ports to which other external services can connect too. The current mapping only include the external port 😔

 
## Insight
Official doc: https://docs.docker.com/compose/compose-file/#ports
 

## Proof Of Work
Before with incorrect port:
![athena-web___volumes_workspace_athena-web__-_____docker-compose_dev_yml__athena-web_](https://user-images.githubusercontent.com/696529/37704603-d8d4feac-2d2b-11e8-9207-cd5d9f9d7e62.png)

After:
![athena-web___volumes_workspace_athena-web__-_____docker-compose_dev_yml__athena-web_](https://user-images.githubusercontent.com/696529/37704556-bc01f6e0-2d2b-11e8-8eb9-12cdb18276cd.png)
