### PR TITLE
Fix: Chrome Driver Net::ReadTimeout when running system specs on CI/CD server

### DIFF
--- a/rails_docker/docker-compose.test.yml
+++ b/rails_docker/docker-compose.test.yml
@@ -12,6 +12,7 @@ services:
   test:
     build:
       context: .
+      shm_size: '512m'
       cache_from:
         - ${DOCKER_IMAGE}:${BRANCH_TAG}
     image: ${DOCKER_IMAGE}:${BRANCH_TAG}

--- a/rails_docker/docker-compose.test.yml
+++ b/rails_docker/docker-compose.test.yml
@@ -22,7 +22,8 @@ services:
     depends_on:
       - db
     volumes:
-      - "ruby-bundle:/bundle"
+      - ruby-bundle:/bundle
+      - /dev/shm:/dev/shm
     environment:
       - RACK_ENV=test
       - RAILS_ENV=test

--- a/rails_docker/docker-compose.test.yml
+++ b/rails_docker/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '3.5'
 
 services:
   db:
@@ -23,7 +23,6 @@ services:
       - db
     volumes:
       - ruby-bundle:/bundle
-      - /dev/shm:/dev/shm
     environment:
       - RACK_ENV=test
       - RAILS_ENV=test

--- a/rails_docker/docker-compose.yml
+++ b/rails_docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     depends_on:
       - db
     volumes:
-      - "ruby-bundle:/bundle"
+      - ruby-bundle:/bundle
     environment:
       - RACK_ENV=production
       - RAILS_ENV=production


### PR DESCRIPTION
## What Happened

System specs that uses Chrome Driver sometimes fail randomly with the error `Net::ReadTimeout`. The issue is related to low memory allocation for the Docker container.

## Insight

* Tried to mount the `dev/shm` volume but the issue still happened: https://github.com/elgalu/docker-selenium/issues/20#issuecomment-133011186
* Requires to increase the size of the `dev/shm` volume: https://github.com/SeleniumHQ/docker-selenium/issues/198
* Requires to upgrade to Docker Compse 3.5: https://docs.docker.com/compose/compose-file/#shm_size. Keeping the Docker Composer versions for dev and production to 3 to have more support on local and host machines and a newer version is not required.