### PR TITLE
Fix: Deprecated code for simplecov

### DIFF
--- a/shared/rspec/support/simplecov.rb
+++ b/shared/rspec/support/simplecov.rb
@@ -1,7 +1,5 @@
 require 'simplecov'
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-    SimpleCov::Formatter::HTMLFormatter
-]
+SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([SimpleCov::Formatter::HTMLFormatter])
 
 if ENV['CIRCLE_ARTIFACTS']
   dir = File.join('..', '..', '..', ENV['CIRCLE_ARTIFACTS'], 'coverage')


### PR DESCRIPTION
## What happened
Got some deprecated code warning in `simplecov` file.
```
/spec/support/simplecov.rb:2:in<top (required)>': [DEPRECATION] ::[] is deprecated.
```


## Insight
Following this referrence.
https://github.com/colszowka/simplecov#using-multiple-formatters

## Issue
[#35]

 