### PR TITLE
Access log file on docker test environment

### DIFF
--- a/rails_docker/docker-compose.test.yml
+++ b/rails_docker/docker-compose.test.yml
@@ -28,6 +28,7 @@ services:
     volumes:
       - "ruby-bundle:/bundle"
       - "${PWD}/tmp/screenshots:/#{app_name}/tmp/screenshots"
+      - "${PWD}/log:/#{app_name}/log"
     environment:
       - RACK_ENV=test
       - RAILS_ENV=test


### PR DESCRIPTION
## What happened
- Right now we mostly don't use docker on local machine, for both development and testing. Docker is only used on testing on CI and sometime for production.
- Sometime environment on docker is different than on non-docker, even for local machine. This may cause some test failing on docker, while still passing on non-docker environment. It's a tough problem to debug, especially if the one failing is a system spec (we can only see the screen shots but not the chrome process). This PR makes the docker environment share the log folder with the host machine, to make easier it for debugging.
 