### PR TITLE
Fix generating the template with URL is NOT working.

### DIFF
--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -1,8 +1,4 @@
 require 'shellwords'
-require_relative 'lib/config'
-require_relative 'lib/rspec'
-require_relative 'lib/test_env'
-require_relative 'lib/linter'
 
 # Add the current directory to the path Thor uses to look up files
 
@@ -27,6 +23,13 @@ def source_paths
   Array(super) + [current_directory]
 end
 
+current_directory
+
+require_relative 'lib/config.rb'
+require_relative 'lib/rspec'
+require_relative 'lib/test_env'
+require_relative 'lib/linter'
+
 # Gemfile
 remove_file 'Gemfile'
 copy_file 'rails_docker/Gemfile.txt', 'Gemfile'
@@ -50,8 +53,8 @@ remove_file '.dockerignore'
 copy_file 'rails_docker/.dockerignore', '.dockerignore'
 gsub_file '.dockerignore', '#{app_name}', "#{app_name}"
 
-copy_file 'rails_docker/.env.test', '.env.test'
-gsub_file '.env.test', '#{app_name}', "#{app_name}"
+copy_file 'rails_docker/.env', '.env'
+gsub_file '.env', '#{app_name}', "#{app_name}"
 
 # Shell script for boot the app inside the Docker image (production)
 copy_file 'rails_docker/start.sh', 'bin/start.sh'

--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -25,9 +25,9 @@ def source_paths
 end
 
 apply 'lib/config.rb'
-apply 'lib/rspec'
-apply 'lib/test_env'
-apply 'lib/linter'
+apply 'lib/rspec.rb'
+apply 'lib/test_env.rb'
+apply 'lib/linter.rb'
 
 # Gemfile
 remove_file 'Gemfile'

--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -24,12 +24,10 @@ def source_paths
   Array(super) + [current_directory]
 end
 
-current_directory
-
-require_relative 'lib/config.rb'
-require_relative 'lib/rspec'
-require_relative 'lib/test_env'
-require_relative 'lib/linter'
+apply 'lib/config.rb'
+apply 'lib/rspec'
+apply 'lib/test_env'
+apply 'lib/linter'
 
 # Gemfile
 remove_file 'Gemfile'

--- a/rails_docker.rb
+++ b/rails_docker.rb
@@ -5,6 +5,7 @@ require 'shellwords'
 def current_directory
   @current_directory ||=
       if __FILE__ =~ %r{\Ahttps?://}
+        require 'tmpdir'
         tempdir = Dir.mktmpdir("rails-templates")
         at_exit { FileUtils.remove_entry(tempdir) }
         git clone: [


### PR DESCRIPTION
ISSUE: #64, #66 
## What happened
This PR fix when generating the template using URL. It shows the error that cannot that cannot find files that required in `rails-docker.rb` because template generator will use URL as path in `require_relative` so it won't work.

Solved by using `apply` instead of `require_relative` that work with `source_path` that we added and both `apply`, `source_path` is provided by `Thor`. 

Also, fix `.env` file name that breaks the when generating application from template.
## Insight
[Here is refrence](https://edgeguides.rubyonrails.org/rails_application_templates.html#advanced-usage) for how `apply` and `source_path` work.
 

## Proof Of Work
Using this command `rails new rails-test -m https://raw.githubusercontent.com/nimbl3/rails-templates/bug/fix-require-from-url/rails_docker.rb -T` to generate rails application.

Rails application generated properly
![rails-test_ _micky_mickys-macbook-pro_ _-zsh_ _212x61](https://user-images.githubusercontent.com/14077479/47908777-8ddda380-dec0-11e8-948c-b455db469b83.png)
