### PR TITLE
Remove the mapping port on docker-compose on test environment.

### DIFF
--- a/rails_docker/docker-compose.test.yml
+++ b/rails_docker/docker-compose.test.yml
@@ -7,7 +7,13 @@ services:
     environment:
       - POSTGRES_DB=#{app_name}_test
     ports:
-      - "5432:5432"
+      - "5432"
+
+  redis:
+    image: redis:4.0.9
+    container_name: #{app_name}_redis
+    ports:
+      - "6379"
 
   test:
     build:


### PR DESCRIPTION
ISSUE #71 

## What happened
We don't need to mapping port when using docker-compose on test environment on Semaphore CI.
 
## Insight
- Remove the mapping port.
- Add the Redis settings. 

## Proof Of Work
The docker-compose on test environment should run without the error on Semaphore CI.